### PR TITLE
Add support for RMT led in toggle led example app

### DIFF
--- a/examples/toggle_led/CMakeLists.txt
+++ b/examples/toggle_led/CMakeLists.txt
@@ -1,10 +1,13 @@
 # The following four lines of boilerplate have to be in your project's CMakeLists
-# in this exact order for cmake to work correctly
+# in this exact order for cmake to wororrectly
 cmake_minimum_required(VERSION 3.5)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
-set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common
+                         ../../components
+                         $ENV{IDF_PATH}/examples/get-started/blink/managed_components/espressif__led_strip)
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(bytebeam_actions_handling_example)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake
+                    main/Kconfig.projbuild)
+project(bytebeam_toggle_led_example)

--- a/examples/toggle_led/main/CMakeLists.txt
+++ b/examples/toggle_led/main/CMakeLists.txt
@@ -1,15 +1,13 @@
-idf_component_register(
-    INCLUDE_DIRS 
-        "."
-    SRCS 
-        "app_main.c"       
-    PRIV_REQUIRES
-        "json"
-        "mqtt"
-        "esp_wifi"	
-        "driver"
-        "nvs_flash"
-        "app_update"
-        "protocol_examples_common"
-        "esp_http_client"
-        "esp_https_ota")
+idf_component_register(SRCS "app_main.c" 
+                       INCLUDE_DIRS "."
+                       PRIV_REQUIRES "bytebeam_esp_sdk"
+									 "esp_wifi"	
+									 "driver"
+                                     "nvs_flash"
+                                     "app_update"
+                                     "mqtt"
+                                     "protocol_examples_common"
+                                     "esp_http_client"
+                                     "esp_https_ota"
+                                     "json"
+                                     "led_strip")

--- a/examples/toggle_led/main/Kconfig.projbuild
+++ b/examples/toggle_led/main/Kconfig.projbuild
@@ -1,0 +1,36 @@
+menu "Example Configuration"
+
+    orsource "$IDF_PATH/examples/common_components/env_caps/$IDF_TARGET/Kconfig.env_caps"
+
+    choice BLINK_LED
+        prompt "Blink LED type"
+        default BLINK_LED_GPIO if IDF_TARGET_ESP32 || IDF_TARGET_ESP32C2
+        default BLINK_LED_RMT
+        help
+            Defines the default peripheral for blink example
+
+        config BLINK_LED_GPIO
+            bool "GPIO"
+        config BLINK_LED_RMT
+            bool "RMT - Addressable LED"
+    endchoice
+
+    config BLINK_GPIO
+        int "Blink GPIO number"
+        range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+        default 8 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32H2 || IDF_TARGET_ESP32C2
+        default 18 if IDF_TARGET_ESP32S2
+        default 48 if IDF_TARGET_ESP32S3
+        default 5
+        help
+            GPIO number (IOxx) to blink on and off or the RMT signal for the addressable LED.
+            Some GPIOs are used for other purposes (flash connections, etc.) and cannot be used to blink.
+
+    config BLINK_PERIOD
+        int "Blink period in ms"
+        range 10 3600000
+        default 1000
+        help
+            Define the blinking period in milliseconds.
+
+endmenu

--- a/examples/toggle_led/main/idf_component.yml
+++ b/examples/toggle_led/main/idf_component.yml
@@ -1,5 +1,0 @@
-## IDF Component Manager Manifest File
-dependencies:
-  bytebeamio/bytebeam-esp-idf-sdk: 
-    version: "*"
-    override_path: "../../../"


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

Closes #<!--Issue Number-->

<!-- If there's an existing issue for your change, please link to it above. If there's not an existing issue, please open one first to make it more likely that this update will be accepted :) 
--->

### Why:
To Implement automatic configuration of GPIO LED pins based on the ESP board.

## Changes Description
Modified app_main.c, CMakeLists.txt, and CMakeLists.txt in the toggle_led application. Added Kconfig.projbuild for configuring GPIO LED pins according to the ESP board type .

## Tests Scenarios
Tested example projects on idf sdk v5.0.2 with ESP32-S2-DevKitC-1 and ESP32 Dev board.

